### PR TITLE
[CHILLIN-4] 이미지 URL 반환

### DIFF
--- a/src/main/kotlin/com/chillin/drawing/DrawingService.kt
+++ b/src/main/kotlin/com/chillin/drawing/DrawingService.kt
@@ -8,8 +8,14 @@ import org.springframework.stereotype.Service
 class DrawingService(
     private val drawingRepository: DrawingRepository
 ) {
-    fun save(filename: String, drawingType: DrawingType, rawPrompt: String? = null, revisedPrompt: String? = null) {
+    fun save(
+        filename: String,
+        drawingType: DrawingType,
+        rawPrompt: String? = null,
+        revisedPrompt: String? = null
+    ): Drawing {
         val drawing = Drawing(filename, drawingType, rawPrompt, revisedPrompt)
-        drawingRepository.save(drawing)
+
+        return drawingRepository.save(drawing)
     }
 }

--- a/src/main/kotlin/com/chillin/drawing/request/ImageGenerationRequest.kt
+++ b/src/main/kotlin/com/chillin/drawing/request/ImageGenerationRequest.kt
@@ -1,4 +1,4 @@
-package com.chillin.drawing
+package com.chillin.drawing.request
 
 data class ImageGenerationRequest(
     val prompt: String,

--- a/src/main/kotlin/com/chillin/drawing/response/ImageGenerationResponse.kt
+++ b/src/main/kotlin/com/chillin/drawing/response/ImageGenerationResponse.kt
@@ -1,0 +1,7 @@
+package com.chillin.drawing.response
+
+data class ImageGenerationResponse(
+    val drawingId: Long,
+    val filename: String,
+    val url: String,
+)


### PR DESCRIPTION
이미지 생성 요청 API를 통해 이미지를 생성하고, 생성된 이미지의 URL을 반환합니다.
Open AI API를 통해 제공되는 기본 url은 1시간 뒤에 만료되기 때문에, S3에 이미지를 업로드하고 해당 이미지의 URL을 받아오도록 했습니다.