### PR TITLE
[CHILLIN-8] 이미지 생성 옵션이 적용되지 않는 버그 수정

### DIFF
--- a/src/main/kotlin/com/chillin/drawing/DrawingController.kt
+++ b/src/main/kotlin/com/chillin/drawing/DrawingController.kt
@@ -25,7 +25,7 @@ class DrawingController(
         val rawPrompt = imageGenerationRequest.prompt
 
         val (url, revisedPrompt) = dallEService.generateImage(rawPrompt)
-        val presignedUrl = s3Service.uploadImage(filename, url)
+        val presignedUrl = s3Service.uploadImage(filename, url, revisedPrompt)
         val savedImage = drawingService.save(filename, DrawingType.GENERATED, rawPrompt, revisedPrompt)
 
         val responseBody = ImageGenerationResponse(savedImage.drawingId, savedImage.filename, presignedUrl)

--- a/src/main/kotlin/com/chillin/openai/DallEService.kt
+++ b/src/main/kotlin/com/chillin/openai/DallEService.kt
@@ -1,20 +1,27 @@
 package com.chillin.openai
 
+import org.springframework.ai.autoconfigure.openai.OpenAiImageProperties
 import org.springframework.ai.image.ImagePrompt
 import org.springframework.ai.openai.OpenAiImageModel
 import org.springframework.ai.openai.api.OpenAiImageApi
 import org.springframework.ai.openai.metadata.OpenAiImageGenerationMetadata
+import org.springframework.ai.retry.RetryUtils
 import org.springframework.stereotype.Service
 
 @Service
 class DallEService(
+    private val openAiImageProperties: OpenAiImageProperties,
     private val openAiImageApi: OpenAiImageApi,
     private val instructionPrefix: String,
     private val instructionPostfix: String,
 ) {
     fun generateImage(instruction: String): Pair<String, String> {
         val prompt = ImagePrompt("$instructionPrefix $instruction $instructionPostfix")
-        val result = OpenAiImageModel(openAiImageApi).call(prompt).result
+        val result = OpenAiImageModel(
+            openAiImageApi,
+            openAiImageProperties.options,
+            RetryUtils.DEFAULT_RETRY_TEMPLATE
+        ).call(prompt).result
 
         val url = result.output.url
         val metadata = result.metadata as OpenAiImageGenerationMetadata

--- a/src/main/kotlin/com/chillin/openai/OpenAiConfig.kt
+++ b/src/main/kotlin/com/chillin/openai/OpenAiConfig.kt
@@ -1,5 +1,6 @@
 package com.chillin.openai
 
+import org.springframework.ai.autoconfigure.openai.OpenAiImageProperties
 import org.springframework.ai.openai.api.OpenAiImageApi
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -9,9 +10,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class OpenAiConfig {
 
-    @Value("\${spring.ai.openai.api-key}")
-    private lateinit var apiKey: String
-
     @Value("\${custom.image.instruction.prefix}")
     private lateinit var instructionPrefix: String
 
@@ -19,8 +17,8 @@ class OpenAiConfig {
     private lateinit var instructionPostfix: String
 
     @Bean
-    fun openAiImageApi(): OpenAiImageApi {
-        return OpenAiImageApi(apiKey)
+    fun openAiImageApi(openAiImageProperties: OpenAiImageProperties): OpenAiImageApi {
+        return OpenAiImageApi(openAiImageProperties.apiKey)
     }
 
     @Bean

--- a/src/main/kotlin/com/chillin/s3/S3Service.kt
+++ b/src/main/kotlin/com/chillin/s3/S3Service.kt
@@ -20,11 +20,12 @@ class S3Service(
     private val bucketName: String,
     private val durationMinutes: Long
 ) {
-    fun uploadImage(filename: String, url: String): String {
+    fun uploadImage(filename: String, url: String, prompt: String): String {
         val request = PutObjectRequest.builder()
             .bucket(bucketName)
             .key(filename)
             .contentType(MediaType.IMAGE_JPEG_VALUE)
+            .metadata(mapOf("x-amz-meta-prompt" to prompt))
             .build()
 
         val imageData = URL(url).openStream().use(InputStream::readBytes)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
         enabled: false
       image:
         enabled: true
+        api-key: ${API_KEY}
         options:
           size: ${IMAGE_SIZE}
   datasource:


### PR DESCRIPTION
기존 코드는 이미지 생성 옵션을 설정파일에서 명시해도 실제 요청에서 포함되지 않는 버그가 있었습니다.

설정파일에서 명시하면 `OpenAiImageModel(openAiImageApi)`  을 호출할 때 default option 으로 적용되는 줄 알았으나, 그렇지 않았습니다.

환경변수가 바인딩되어 있는 `OpenAiImageProperties` 클래스의 `option` 필드를 통해 생성 옵션을 `OpenAiImageModel` 객체를 생성할 때 직접 지정해주어 해결하였습니다.

---
이미지 업로드할 때 메타 정보로 실체 요청시 사용된 (수정된) 프롬프트를 포함하도록 했습니다.