### PR TITLE
[CHILLIN-11] 엡손 커넥트 API 인증 부분 연동

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("software.amazon.awssdk:s3:2.26.3")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis:3.3.0")
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")
@@ -44,6 +45,9 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/chillin/connect/EpsonConnectApi.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectApi.kt
@@ -1,0 +1,47 @@
+package com.chillin.connect
+
+import com.chillin.connect.response.AuthenticationResponse
+import okhttp3.Request
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class EpsonConnectApi(
+    private val epsonConnectProperties: EpsonConnectProperties,
+    private val epsonConnectClient: EpsonConnectClient,
+    private val redisTemplate: StringRedisTemplate
+) {
+    companion object {
+        private const val BASE_URL = "https://api.epsonconnect.com"
+    }
+
+    private val logger = LoggerFactory.getLogger(EpsonConnectApi::class.java)
+
+    fun authenticate(): String {
+        return redisTemplate.opsForValue().get("accessToken") ?: run {
+            logger.info("Authenticating with Epson Connect API")
+
+            val request = Request.Builder()
+                .post(epsonConnectProperties.authenticationRequest())
+                .url("$BASE_URL/api/1/printing/oauth2/auth/token?subject=printer")
+                .header(HttpHeaders.CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, epsonConnectProperties.basicHeader())
+                .build()
+
+            epsonConnectClient.call(request)
+                .bind(AuthenticationResponse::class.java)
+                ?.run {
+                    redisTemplate.opsForValue().set("deviceId", subjectId)
+                    redisTemplate.opsForValue().set("accessToken", accessToken)
+                    redisTemplate.expire("accessToken", expiresIn, TimeUnit.SECONDS)
+                    logger.info("Authentication successful")
+
+                    accessToken
+                } ?: throw RuntimeException("Authentication failed")
+        }
+    }
+}

--- a/src/main/kotlin/com/chillin/connect/EpsonConnectClient.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectClient.kt
@@ -1,0 +1,36 @@
+package com.chillin.connect
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+
+class EpsonConnectClient(
+    private val okHttpClient: OkHttpClient
+) {
+
+    private val logger = LoggerFactory.getLogger(EpsonConnectClient::class.java)
+
+    fun call(request: Request): Response {
+        logger.info("${request.method} ${request.url}")
+        logger.info("Headers: ${request.headers.toMap()}")
+
+        return okHttpClient.newCall(request)
+            .execute()
+            .apply(::handleResponse)
+    }
+
+    private fun handleResponse(response: Response) {
+        takeUnless { response.isSuccessful }?.let {
+            logger.error("${HttpStatus.valueOf(response.code)}: ${response.message}")
+            throw RuntimeException("Request failed")
+        }
+        logger.info("${HttpStatus.valueOf(response.code)} ${response.protocol}")
+    }
+}
+
+fun <T> Response.bind(clazz: Class<T>): T? {
+    return body?.let { jacksonObjectMapper().readValue(it.string(), clazz) }
+}

--- a/src/main/kotlin/com/chillin/connect/EpsonConnectConfig.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectConfig.kt
@@ -1,0 +1,16 @@
+package com.chillin.connect
+
+import okhttp3.OkHttpClient
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(EpsonConnectProperties::class)
+class EpsonConnectConfig {
+
+    @Bean
+    fun epsonConnectClient(): EpsonConnectClient {
+        return EpsonConnectClient(OkHttpClient())
+    }
+}

--- a/src/main/kotlin/com/chillin/connect/EpsonConnectProperties.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectProperties.kt
@@ -1,0 +1,23 @@
+package com.chillin.connect
+
+import com.chillin.connect.request.AuthenticationRequest
+import okhttp3.FormBody
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.http.HttpHeaders
+import java.nio.charset.Charset
+
+@ConfigurationProperties(prefix = "custom.epson-connect")
+class EpsonConnectProperties(
+    private var printerAddress: String,
+    private var clientId: String,
+    private var clientSecret: String,
+) {
+
+    fun basicHeader(charset: Charset? = null): String {
+        return "Basic ${HttpHeaders.encodeBasicAuth(clientId, clientSecret, charset)}"
+    }
+
+    fun authenticationRequest(): FormBody {
+        return AuthenticationRequest(printerAddress).toFormBody()
+    }
+}

--- a/src/main/kotlin/com/chillin/connect/request/AuthenticationRequest.kt
+++ b/src/main/kotlin/com/chillin/connect/request/AuthenticationRequest.kt
@@ -1,0 +1,18 @@
+package com.chillin.connect.request
+
+import okhttp3.FormBody
+
+data class AuthenticationRequest(
+    private val username: String
+) {
+    private val grantType = "password"
+    private val password = ""
+
+    fun toFormBody(): FormBody {
+        return FormBody.Builder()
+            .add("grant_type", grantType)
+            .add("username", username)
+            .add("password", password)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/chillin/connect/response/AuthenticationResponse.kt
+++ b/src/main/kotlin/com/chillin/connect/response/AuthenticationResponse.kt
@@ -1,0 +1,14 @@
+package com.chillin.connect.response
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(SnakeCaseStrategy::class)
+data class AuthenticationResponse(
+    val tokenType: String,
+    val accessToken: String,
+    val expiresIn: Long,
+    val refreshToken: String,
+    val subjectType: String,
+    val subjectId: String
+)

--- a/src/main/kotlin/com/chillin/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/chillin/redis/RedisConfig.kt
@@ -1,0 +1,30 @@
+package com.chillin.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@Configuration
+class RedisConfig {
+
+    @Value("\${spring.data.redis.host}")
+    private lateinit var host: String
+
+    @Value("\${spring.data.redis.port}")
+    private lateinit var port: String
+
+    @Bean
+    fun lettuceConnectionFactory(): LettuceConnectionFactory {
+        return LettuceConnectionFactory(host, port.toInt())
+    }
+
+    @Bean
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): StringRedisTemplate {
+        return StringRedisTemplate().apply {
+            connectionFactory = redisConnectionFactory
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 logging:
   level:
     web: debug
@@ -35,3 +39,7 @@ custom:
     bucket:
       name: ${AWS_BUCKET_NAME}
     durationMinutes: ${AWS_DURATION_MINUTES}
+  epson-connect:
+    printer-address: ${EPSON_PRINTER_ADDRESS}
+    client-id: ${EPSON_CLIENT_ID}
+    client-secret: ${EPSON_CLIENT_SECRET}

--- a/src/test/kotlin/com/chillin/connect/EpsonConnectTest.kt
+++ b/src/test/kotlin/com/chillin/connect/EpsonConnectTest.kt
@@ -1,0 +1,56 @@
+package com.chillin.connect
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@SpringBootTest
+class EpsonConnectTest(
+    private val epsonConnectApi: EpsonConnectApi,
+    private val redisTemplate: StringRedisTemplate
+) : BehaviorSpec({
+
+    given("인증을 한번도 하지 않았을 때") {
+        `when`("인증을 시도해 성공하면") {
+            val accessToken = epsonConnectApi.authenticate()
+            then("레디스에 액세스 토큰이 저장되어야 한다.") {
+                val redisAccessToken = redisTemplate.opsForValue().get("accessToken")
+
+                redisAccessToken shouldNotBe null
+                accessToken shouldBe redisAccessToken
+            }
+        }
+    }
+
+    given("인증을 한번 진행하고") {
+        val accessToken = epsonConnectApi.authenticate()
+        `when`("토큰이 만료된 후 인증을 한번 더 시도하면") {
+            redisTemplate.opsForValue().getAndDelete("accessToken")
+            epsonConnectApi.authenticate()
+            then("만료된 토큰과 새로 발급된 토큰이 달라야 한다.") {
+                val redisAccessToken = redisTemplate.opsForValue().get("accessToken")
+
+                redisAccessToken shouldNotBe null
+                accessToken shouldNotBe redisAccessToken
+            }
+        }
+    }
+
+    given("인증을 이미 했을 때") {
+        `when`("토큰이 만료되지 않고 인증을 한번 더 시도하면") {
+            val accessToken = epsonConnectApi.authenticate()
+            then("두 토큰은 같아야 한다.") {
+                accessToken shouldBe epsonConnectApi.authenticate()
+            }
+        }
+    }
+}) {
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        val keys = redisTemplate.keys("*")
+        redisTemplate.delete(keys)
+    }
+}


### PR DESCRIPTION
엡손 커넥트 API 요청에 가장 기본이 되는 인증 부분을 연동했습니다.

- HTTP 요청 라이브러리로 스프링이 내장하고 있는 `RestClient`를 사용하려 하였으나, 서버에서 계속 연결을 종료하는 알 수 없는 이슈로(`GOAWAY received`) `OkHttp`를 적용했습니다.
- 액세스 토큰 및 디바이스 정보를 저장하기 위해 인메모리 디비인 레디스를 적용했습니다.
- TTL을 설정해 액세스 토큰이 만료되지 않으면 인증 요청을 추가로 보내지 않고 레디스에 저장된 값을 사용하도록 했습니다.

## TODO
- [x] #12 
- [x] #13 
- [x] #14 

