### PR TITLE
[CHILLIN-19] 스캔 데이터 저장

### DIFF
--- a/src/main/kotlin/com/chillin/connect/EpsonConnectController.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectController.kt
@@ -1,0 +1,30 @@
+package com.chillin.connect
+
+import com.chillin.drawing.DrawingService
+import com.chillin.s3.S3Service
+import com.chillin.type.DrawingType
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+class EpsonConnectController(
+    private val drawingService: DrawingService,
+    private val s3Service: S3Service
+) {
+
+    private val logger = LoggerFactory.getLogger(EpsonConnectController::class.java)
+
+    @PostMapping("/scan")
+    fun receiveScanData(@RequestParam files: Map<String, MultipartFile>) {
+        logger.info("Received {} files={}", files.values.size, files.values.map(MultipartFile::getOriginalFilename))
+
+        files.values.forEach { file ->
+            val (filename, _) = s3Service.uploadImage(file)
+            drawingService.save(filename, DrawingType.SCANNED)
+            logger.info("Saved file to database={}", filename)
+        }
+    }
+}

--- a/src/main/kotlin/com/chillin/connect/EpsonConnectService.kt
+++ b/src/main/kotlin/com/chillin/connect/EpsonConnectService.kt
@@ -75,11 +75,11 @@ class EpsonConnectService(
         logger.info("Uploading file to print")
         val (byteArray, contentType) = fileData
         val binary = byteArray.toRequestBody(contentType.toMediaType())
-        val mediaSubtype = MediaSubtype.parse(contentType)
+        val extension = MediaSubtype.parse(contentType)
 
         val request = Request.Builder()
             .post(binary)
-            .url("$uploadUri&File=1.$mediaSubtype")
+            .url("$uploadUri&File=1.$extension")
             .build()
 
         val response = epsonConnectClient.call(request)

--- a/src/main/kotlin/com/chillin/drawing/DrawingController.kt
+++ b/src/main/kotlin/com/chillin/drawing/DrawingController.kt
@@ -2,19 +2,17 @@ package com.chillin.drawing
 
 import com.chillin.connect.EpsonConnectService
 import com.chillin.connect.request.PrintSettingsRequest
-import com.chillin.type.DrawingType
 import com.chillin.drawing.request.ImageGenerationRequest
 import com.chillin.drawing.request.ImagePrintRequest
 import com.chillin.drawing.response.ImageGenerationResponse
 import com.chillin.openai.DallEService
 import com.chillin.s3.S3Service
-import com.chillin.type.MediaSubtype
+import com.chillin.type.DrawingType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.*
 
 @RestController
 @RequestMapping("/drawings")
@@ -26,13 +24,10 @@ class DrawingController(
 ) {
     @PostMapping("/gen")
     fun generateDrawing(@RequestBody imageGenerationRequest: ImageGenerationRequest): ResponseEntity<ImageGenerationResponse> {
-        val filename = "generative/${UUID.randomUUID()}.${MediaSubtype.JPEG.value}"
-        val (rawPrompt) = imageGenerationRequest
-
+        val rawPrompt = imageGenerationRequest.prompt
         val (url, revisedPrompt) = dallEService.generateImage(rawPrompt)
-        val presignedUrl = s3Service.uploadImage(filename, url, revisedPrompt)
+        val (filename, presignedUrl) = s3Service.uploadImage(url, revisedPrompt)
         val savedImage = drawingService.save(filename, DrawingType.GENERATED, rawPrompt, revisedPrompt)
-
         val responseBody = ImageGenerationResponse(savedImage.drawingId, savedImage.filename, presignedUrl)
 
         return ResponseEntity.status(201).body(responseBody)

--- a/src/main/kotlin/com/chillin/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/chillin/redis/RedisConfig.kt
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 
@@ -16,9 +18,14 @@ class RedisConfig {
     @Value("\${spring.data.redis.port}")
     private lateinit var port: String
 
+    @Value("\${spring.data.redis.password}")
+    private var password: String? = null
+
     @Bean
     fun lettuceConnectionFactory(): LettuceConnectionFactory {
-        return LettuceConnectionFactory(host, port.toInt())
+        val config = RedisStandaloneConfiguration(host, port.toInt())
+        config.password = RedisPassword.of(password)
+        return LettuceConnectionFactory(config)
     }
 
     @Bean

--- a/src/main/kotlin/com/chillin/type/MediaSubtype.kt
+++ b/src/main/kotlin/com/chillin/type/MediaSubtype.kt
@@ -9,8 +9,8 @@ enum class MediaSubtype(val value: String) {
     FORM_DATA("form-data");
 
     companion object {
-        fun parse(contentTypeValue: String): MediaSubtype {
-            return when (contentTypeValue.substringAfterLast('.')) {
+        fun parse(contentTypeValue: String?): MediaSubtype {
+            return when (contentTypeValue?.substringAfterLast('.')) {
                 PDF.value -> PDF
                 JPEG.value -> JPEG
                 JSON.value -> JSON

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,10 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+  servlet:
+    multipart:
+      max-file-size: ${MAX_FILE_SIZE:10MB}
 logging:
   level:
     web: debug


### PR DESCRIPTION
복합기로부터 스캔한 데이터를 받아올 수 있습니다.

- 스캔 파일 용량이 기본 설정값인 1M을 넘는 경우가 많아, 10M로 설정해주었습니다.
- 배포 환경에서 안전한 사용을 위해 레디스 비밀번호 설정 정보를 추가했습니다.

