### PR TITLE
[CHILLIN-31] 배경 제거한 이미지 업로드시 미디어 타입이 초기화 되는 버그 수정

### DIFF
--- a/src/main/kotlin/com/chillin/adobe/AdobeService.kt
+++ b/src/main/kotlin/com/chillin/adobe/AdobeService.kt
@@ -58,11 +58,11 @@ class AdobeService(
             .header(apiKeyHeader.first, apiKeyHeader.second)
             .build()
 
-        val response = httpClient.call(request)
-        return response.apply {
-            if (isSuccessful) logger.info("Background removal request successful")
+        return httpClient.call(request).use { response ->
+            if (response.isSuccessful) logger.info("Background removal request successful")
             else logger.error("Background removal request failed: $response")
-        }.isSuccessful
+            response.isSuccessful
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/chillin/drawing/DrawingService.kt
+++ b/src/main/kotlin/com/chillin/drawing/DrawingService.kt
@@ -2,26 +2,38 @@ package com.chillin.drawing
 
 import com.chillin.drawing.domain.Drawing
 import com.chillin.type.DrawingType
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class DrawingService(
     private val drawingRepository: DrawingRepository
 ) {
+    private val logger = LoggerFactory.getLogger(DrawingService::class.java)
+
     fun save(
         pathname: String,
         drawingType: DrawingType,
         rawPrompt: String? = null,
         revisedPrompt: String? = null
     ): Drawing {
+        logger.info("Saving drawing to db...")
         val drawing = Drawing(pathname, drawingType, rawPrompt, revisedPrompt)
-        return drawingRepository.save(drawing)
+
+        return drawingRepository.save(drawing).apply {
+            logger.info("Saved drawing to db: drawingId=${drawingId}, pathname=$pathname, drawingType=$drawingType, rawPrompt=$rawPrompt, revisedPrompt=$revisedPrompt")
+        }
     }
 
     fun getNameById(drawingId: Long): String {
+        logger.info("Querying drawing by ID: drawingId=$drawingId...")
+
         return drawingRepository.findById(drawingId)
             .orElseThrow { NoSuchElementException("Drawing not found") }
-            .pathname
+            .let {
+                logger.info("Found drawing: pathname=\"${it.pathname}\"")
+                it.pathname
+            }
     }
 
     fun getAllByType(type: DrawingType) = drawingRepository.findAllByTypeOrderByCreatedAtDesc(type)

--- a/src/main/kotlin/com/chillin/epson/EpsonConnectController.kt
+++ b/src/main/kotlin/com/chillin/epson/EpsonConnectController.kt
@@ -33,8 +33,6 @@ class EpsonConnectController(
 
             adobeService.cutout(downloadUrl, uploadUrl)
             drawingService.save(pathname, DrawingType.SCANNED)
-
-            logger.info("Saved file \"$pathname\" to database")
         }
     }
 }

--- a/src/main/kotlin/com/chillin/epson/EpsonConnectService.kt
+++ b/src/main/kotlin/com/chillin/epson/EpsonConnectService.kt
@@ -84,10 +84,14 @@ class EpsonConnectService(
             .url("$uploadUri&File=1.$extension")
             .build()
 
-        val response = httpClient.call(request)
-        logger.info("Uploaded file to Epson Connect successfully")
-
-        return response.isSuccessful
+        return httpClient.call(request).use { response ->
+            if (response.isSuccessful.not()) {
+                logger.error("Failed to upload file to Epson Connect")
+                throw RuntimeException("Failed to upload file to Epson Connect")
+            }
+            logger.info("Uploaded file to Epson Connect successfully")
+            response.isSuccessful
+        }
     }
 
     fun print(fileData: Pair<ByteArray, String>, printSettings: PrintSettingsRequest): Boolean {
@@ -104,10 +108,14 @@ class EpsonConnectService(
             .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
             .build()
 
-        val response = httpClient.call(request)
-        logger.info("Printed file successfully")
-
-        return response.isSuccessful
+        return httpClient.call(request).use { response ->
+            if (response.isSuccessful.not()) {
+                logger.error("Failed to print file")
+                throw RuntimeException("Failed to print file")
+            }
+            logger.info("Printed file successfully")
+            response.isSuccessful
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/chillin/epson/config/EpsonConnectConfig.kt
+++ b/src/main/kotlin/com/chillin/epson/config/EpsonConnectConfig.kt
@@ -1,8 +1,6 @@
 package com.chillin.epson.config
 
-import com.chillin.http.HttpClient
 import okhttp3.FormBody
-import okhttp3.OkHttpClient
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -10,11 +8,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @EnableConfigurationProperties(EpsonConnectProperties::class)
 class EpsonConnectConfig {
-
-    @Bean
-    fun epsonConnectClient(): HttpClient {
-        return HttpClient(OkHttpClient())
-    }
 
     @Bean
     fun basicHeader(epsonConnectProperties: EpsonConnectProperties): String {

--- a/src/main/kotlin/com/chillin/http/HttpConfig.kt
+++ b/src/main/kotlin/com/chillin/http/HttpConfig.kt
@@ -1,0 +1,14 @@
+package com.chillin.http
+
+import okhttp3.OkHttpClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class HttpConfig {
+
+    @Bean
+    fun httpClient(): HttpClient {
+        return HttpClient(OkHttpClient())
+    }
+}

--- a/src/main/kotlin/com/chillin/motion/MotionRequest.kt
+++ b/src/main/kotlin/com/chillin/motion/MotionRequest.kt
@@ -1,7 +1,0 @@
-package com.chillin.motion
-
-import com.chillin.motion.request.MotionType
-
-data class MotionRequest(
-    val motionType: MotionType
-)

--- a/src/main/kotlin/com/chillin/motion/MotionService.kt
+++ b/src/main/kotlin/com/chillin/motion/MotionService.kt
@@ -5,9 +5,9 @@ import com.chillin.motion.request.MotionType
 import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.ResponseBody
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 @Service
 class MotionService(
@@ -26,11 +26,9 @@ class MotionService(
             .url("$baseUrl/motion")
             .build()
 
-        val gifBytes = httpClient.call(request)
-            .body
-            ?.let(ResponseBody::bytes)
-            ?: throw RuntimeException("Failed to receive response from motion service.")
-
+        val gifBytes = httpClient.call(request, 5L, TimeUnit.MINUTES).use { response ->
+            response.body?.bytes() ?: throw RuntimeException("Failed to receive response from motion service.")
+        }
         return gifBytes
     }
 }

--- a/src/main/kotlin/com/chillin/motion/request/MotionRequest.kt
+++ b/src/main/kotlin/com/chillin/motion/request/MotionRequest.kt
@@ -1,0 +1,5 @@
+package com.chillin.motion.request
+
+data class MotionRequest(
+    val motionType: MotionType
+)

--- a/src/main/kotlin/com/chillin/type/MediaSubtype.kt
+++ b/src/main/kotlin/com/chillin/type/MediaSubtype.kt
@@ -1,5 +1,6 @@
 package com.chillin.type
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 
 enum class MediaSubtype(val value: String) {
@@ -10,7 +11,10 @@ enum class MediaSubtype(val value: String) {
     FORM_DATA("form-data");
 
     companion object {
+        private val logger = LoggerFactory.getLogger(MediaSubtype::class.java)
+
         fun parse(contentTypeValue: String?): MediaSubtype {
+            logger.info("Parsing media subtype from \"$contentTypeValue\"")
             return when (contentTypeValue?.substringAfterLast('.')) {
                 PDF.value -> PDF
                 JPEG.value -> JPEG


### PR DESCRIPTION
스캔 이미지의 미디어타입이 `*/*` 로 변경되었던 이유는 업로드용 PresignedUrl 을 생성할 때 미디어 타입을 지정하지 않았기 때문입니다.
따라서, 관련 로직에 미디어타입을 명시함으로써 버그를 해결했습니다.

또한, 모션(애니메이션) 타입에 따라 타임아웃이 걸리는 문제를 발견해 타임아웃 시간을 5분으로 늘렸습니다.
현재까지 확인된 모션별 응답시간은 다음과 같습니다.

- `dance`: 40초대
- `hello` : 3분 초과
- `jump` : 2분대
- `zombie`: ?