### PR TITLE
[CHILLIN-37] 스캔 이미지 배경 제거가 되지 않는 버그 수정

### DIFF
--- a/src/main/kotlin/com/chillin/adobe/AdobeService.kt
+++ b/src/main/kotlin/com/chillin/adobe/AdobeService.kt
@@ -2,6 +2,7 @@ package com.chillin.adobe
 
 import com.chillin.adobe.request.AdobeCutoutRequest
 import com.chillin.adobe.response.AdobeAuthResponse
+import com.chillin.adobe.response.AdobeStatusResponse
 import com.chillin.http.HttpClient
 import com.chillin.http.HttpClient.Companion.bind
 import com.chillin.redis.RedisKeyFactory
@@ -46,7 +47,7 @@ class AdobeService(
         }
     }
 
-    fun cutout(srcUrl: String, dstUrl: String): Boolean {
+    fun cutout(srcUrl: String, dstUrl: String): AdobeStatusResponse {
         logger.info("Requesting background removal to Adobe Photoshop API")
 
         val accessToken = authenticate()
@@ -58,11 +59,9 @@ class AdobeService(
             .header(apiKeyHeader.first, apiKeyHeader.second)
             .build()
 
-        return httpClient.call(request).use { response ->
-            if (response.isSuccessful) logger.info("Background removal request successful")
-            else logger.error("Background removal request failed: $response")
-            response.isSuccessful
-        }
+        return httpClient.call(request)
+            .bind(AdobeStatusResponse::class.java)
+            ?: throw RuntimeException("Failed to request background removal to Adobe Photoshop API")
     }
 
     companion object {

--- a/src/main/kotlin/com/chillin/adobe/response/AdobeStatusResponse.kt
+++ b/src/main/kotlin/com/chillin/adobe/response/AdobeStatusResponse.kt
@@ -1,0 +1,7 @@
+package com.chillin.adobe.response
+
+data class AdobeStatusResponse(val _links: Links) {
+    data class Links(val self: Self) {
+        data class Self(val href: String)
+    }
+}

--- a/src/main/kotlin/com/chillin/motion/MotionService.kt
+++ b/src/main/kotlin/com/chillin/motion/MotionService.kt
@@ -23,7 +23,7 @@ class MotionService(
 
         val request = Request.Builder()
             .post(formData)
-            .url("$baseUrl/motion")
+            .url("$baseUrl/motion/")
             .build()
 
         val gifBytes = httpClient.call(request, 5L, TimeUnit.MINUTES).use { response ->

--- a/src/main/kotlin/com/chillin/s3/S3Service.kt
+++ b/src/main/kotlin/com/chillin/s3/S3Service.kt
@@ -92,11 +92,11 @@ class S3Service(
     }
 
     fun getImageUrlForPOST(pathname: String): String {
-        val contentType = MediaSubtype.parse(pathname).toMediaTypeValue()
+        logger.info("Generating presigned URL for uploading image to S3...: pathname=$pathname")
+
         val putObjectRequest = PutObjectRequest.builder()
             .bucket(bucketName)
             .key(pathname)
-            .contentType(contentType)
             .build()
 
         val request = PutObjectPresignRequest.builder()
@@ -104,9 +104,10 @@ class S3Service(
             .signatureDuration(Duration.ofMinutes(durationMinutes))
             .build()
 
-        return s3Presigner.presignPutObject(request)
-            .url()
-            .toString()
+        return s3Presigner.presignPutObject(request).let {
+            logger.info("Generated presigned URL for uploading image to S3: ${it.url()}")
+            it.url().toExternalForm()
+        }
     }
 
     fun getImageData(pathname: String): Pair<ByteArray, String> {

--- a/src/main/kotlin/com/chillin/type/MediaSubtype.kt
+++ b/src/main/kotlin/com/chillin/type/MediaSubtype.kt
@@ -8,7 +8,8 @@ enum class MediaSubtype(val value: String) {
     JPEG("jpeg"),
     GIF("gif"),
     JSON("json"),
-    FORM_DATA("form-data");
+    FORM_DATA("form-data"),
+    ALL("*");
 
     companion object {
         private val logger = LoggerFactory.getLogger(MediaSubtype::class.java)
@@ -20,11 +21,13 @@ enum class MediaSubtype(val value: String) {
                 JPEG.value -> JPEG
                 GIF.value -> GIF
                 JSON.value -> JSON
+                ALL.value -> ALL
                 MediaType.APPLICATION_PDF_VALUE -> PDF
                 MediaType.IMAGE_JPEG_VALUE -> JPEG
                 MediaType.IMAGE_GIF_VALUE -> GIF
                 MediaType.APPLICATION_JSON_VALUE -> JSON
                 MediaType.MULTIPART_FORM_DATA_VALUE -> FORM_DATA
+                MediaType.ALL_VALUE -> ALL
                 else -> throw IllegalArgumentException("Unsupported media type")
             }
         }
@@ -33,7 +36,7 @@ enum class MediaSubtype(val value: String) {
     fun toMediaTypeValue(): String {
         return when (this) {
             PDF -> MediaType.APPLICATION_PDF_VALUE
-            JPEG -> MediaType.IMAGE_JPEG_VALUE
+            JPEG, ALL -> MediaType.IMAGE_JPEG_VALUE
             GIF -> MediaType.IMAGE_GIF_VALUE
             JSON -> MediaType.APPLICATION_JSON_VALUE
             FORM_DATA -> MediaType.MULTIPART_FORM_DATA_VALUE


### PR DESCRIPTION
Presigned URL 생성시 Content-Type 및 메타데이터 지정이 문제였음. (#32)

이걸 지정해주면 요청 정보와 관계없이 생성된 오브젝트의 미디어타입과 메타데이타 정보를 설정하는 것으로 생각했는데, 해당 URL을 통해 객체를 업로드하는 오리진에서 presigned url 생성시 지정한 미디어타입(`image/jpeg`)과 메타데이타에 맞게 요청을 보냈어야 하는 것이었다. 그런데 어도비 포토샵 API는 Content-Type 을 ALL 미디어 타입(`*/*`)으로 보내주기 때문에, 이 과정에서 문제가 발생한 것이다.

객체 복사 방식을 통한 메타데이터 업데이트가 되지 않아, ALL 미디어타입(`*/*`)을 이미지 미디어타입으로 분기하도록 설정